### PR TITLE
remove missing kitten url

### DIFF
--- a/data/kittens.yml
+++ b/data/kittens.yml
@@ -263,11 +263,6 @@
   imageUrl: "http://www.aktpics.com/My-Galleries/Animals/njcattitudeorg-Cat-and-Kitten/njcattitude2008051147/293613387_cUzj4-L.jpg"
   imageAlt: "5/11/2008: Alice and her 7 kittens."
 
-- url: "http://www.quarkview.com/Animals/Cat-and-Dog-1/11544493_qmFFCJ#!i=814007549&k=fWGF2&lb=1&s=A"
-  title: "Mitha Malka: 2 month kitten nap"
-  imageUrl: "http://www.quarkview.com/Animals/Cat-and-Dog-1/empty/814007549_fWGF2-L-1.jpg"
-  imageAlt: "Mitha Malka: 2 month kitten nap"
-
 - url: "http://www.carllengyel.com/Pets/Kittens-Cats/9711733_mNRP4V#!i=657756269&k=W5nxT&lb=1&s=A"
   title: "- Four black and gray tabby cat kittens."
   imageUrl: "http://www.carllengyel.com/Pets/Kittens-Cats/2006Jun2Kittens/657756269_W5nxT-L-1.jpg"


### PR DESCRIPTION
At least as of June 18, http://www.emergencykitten.com/kitten/fd36e90f no longer works.